### PR TITLE
Allow larger offset when using x to ignore bytes

### DIFF
--- a/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
+++ b/tasmota/tasmota_xsns_sensor/xsns_53_sml.ino
@@ -2033,7 +2033,7 @@ void SML_Decode(uint8_t index) {
               } else {
                 mp++;
                 if (isdigit(*mp)) {
-                  uint8_t skip = strtol((char*)mp, (char**)&mp, 10);
+                  uint16_t skip = strtol((char*)mp, (char**)&mp, 10);
                   cp += skip;
                 }
               }


### PR DESCRIPTION
STW Klagenfurt sends 355 bytes, and the interesting values starts somewhere at position 304. Therefor we need to set a larger uint range to allow more than 255 bytes to ignore.

## Description:

Discussion open https://github.com/arendst/Tasmota/discussions/21359

## Checklist:
  - [x] The pull request is done against the latest development branch
  - [x] Only relevant files were touched
  - [x] Only one feature/fix was added per PR and the code change compiles without warnings
  - [ ] The code change is tested and works with Tasmota core ESP8266 V.2.7.6
  - [x] The code change is tested and works with Tasmota core ESP32 V.3.0.0
  - [x] I accept the [CLA](https://github.com/arendst/Tasmota/blob/development/CONTRIBUTING.md#contributor-license-agreement-cla).

_NOTE: The code change must pass CI tests. **Your PR cannot be merged unless tests pass**_
